### PR TITLE
Feature implement driven adapter r2dbc

### DIFF
--- a/applications/app-service/build.gradle
+++ b/applications/app-service/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'org.springframework.boot'
 
 dependencies {
+	implementation 'org.reactivecommons.utils:object-mapper:0.1.0'
+	implementation project(':r2dbc-postgresql')
     implementation project(':model')
     implementation project(':usecase')
     implementation 'org.springframework.boot:spring-boot-starter'
@@ -23,4 +25,3 @@ bootJar {
     // Sets output jar name
     archiveFileName = "${project.getParent().getName()}.${archiveExtension.get()}"
 }
-

--- a/applications/app-service/build.gradle
+++ b/applications/app-service/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'org.springframework.boot'
 
 dependencies {
+	implementation project(':reactive-web')
 	implementation 'org.reactivecommons.utils:object-mapper:0.1.0'
 	implementation project(':r2dbc-postgresql')
     implementation project(':model')

--- a/applications/app-service/src/main/java/co/com/franquicias/config/ObjectMapperConfig.java
+++ b/applications/app-service/src/main/java/co/com/franquicias/config/ObjectMapperConfig.java
@@ -1,0 +1,16 @@
+package co.com.franquicias.config;
+
+import org.reactivecommons.utils.ObjectMapper;
+import org.reactivecommons.utils.ObjectMapperImp;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapperImp();
+    }
+
+}

--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -14,7 +14,7 @@ spring:
 adapters:
   r2dbc:
     host: "localhost"
-    port: 5432
+    port: 5435
     database: "franquicia_db"
     schema: "public"
     username: "franquicia_user"

--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -1,17 +1,16 @@
-##Spring Configuration
 server:
   port: 8080
 spring:
   application:
-    name: api-franquicias
+    name: "api-franquicias"
   devtools:
     add-properties: false
   h2:
     console:
       enabled: true
-      path: /h2
+      path: "/h2"
   profiles:
-    include:
+    include: null
 adapters:
   r2dbc:
     host: "localhost"
@@ -26,6 +25,17 @@ adapters:
       enabled: true
 spring-doc:
   api-docs:
-    path: /v3/api-docs
+    path: "/v3/api-docs"
   swagger-ui:
-    path: /swagger
+    path: "/swagger"
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health,prometheus"
+  endpoint:
+    health:
+      probes:
+        enabled: true
+cors:
+  allowed-origins: "http://localhost:4200,http://localhost:8080"

--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -12,3 +12,20 @@ spring:
       path: /h2
   profiles:
     include:
+adapters:
+  r2dbc:
+    host: "localhost"
+    port: 5432
+    database: "franquicia_db"
+    schema: "public"
+    username: "franquicia_user"
+    password: "franquicia_pass"
+  data:
+    r2dbc:
+      repositories: null
+      enabled: true
+spring-doc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger

--- a/applications/app-service/src/test/java/co/com/franquicias/config/ObjectMapperConfigTest.java
+++ b/applications/app-service/src/test/java/co/com/franquicias/config/ObjectMapperConfigTest.java
@@ -1,0 +1,20 @@
+package co.com.franquicias.config;
+
+import org.junit.jupiter.api.Test;
+import org.reactivecommons.utils.ObjectMapper;
+import org.reactivecommons.utils.ObjectMapperImp;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ObjectMapperConfigTest {
+
+    @Test
+    void testObjectMapperBean() {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(ObjectMapperConfig.class);
+        ObjectMapper objectMapper = context.getBean(ObjectMapper.class);
+        assertNotNull(objectMapper);
+        assertTrue(objectMapper instanceof ObjectMapperImp);
+        context.close();
+    }
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,23 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:15
+    container_name: franquicia-db
+    environment:
+      POSTGRES_DB: franquicia_db
+      POSTGRES_USER: franquicia_user
+      POSTGRES_PASSWORD: franquicia_pass
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+#      - ./init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
+    networks:
+      - franquicia-network
+
+volumes:
+  pgdata:
+
+networks:
+  franquicia-network:
+    driver: bridge

--- a/domain/model/src/main/java/co/com/franquicias/model/franquicia/Franquicia.java
+++ b/domain/model/src/main/java/co/com/franquicias/model/franquicia/Franquicia.java
@@ -3,14 +3,15 @@ import co.com.franquicias.model.sucursal.Sucursal;
 import lombok.Builder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-//import lombok.NoArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @Setter
-//@NoArgsConstructor
+@NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
 public class Franquicia {
@@ -19,5 +20,8 @@ public class Franquicia {
     private List<Sucursal> listaSucursales;
 
     public Franquicia(Integer idFranquicia, String nombreFranquicia) {
+        this.idFranquicia = idFranquicia;
+        this.nombreFranquicia = nombreFranquicia;
+        this.listaSucursales = new ArrayList<>();
     }
 }

--- a/domain/usecase/src/main/java/co/com/franquicias/usecase/franquicia/FranquiciaUseCase.java
+++ b/domain/usecase/src/main/java/co/com/franquicias/usecase/franquicia/FranquiciaUseCase.java
@@ -16,10 +16,12 @@ public class FranquiciaUseCase implements IFranquiciaUseCase{
     private final FranquiciaRepository franquiciaRepository;
     @Override
     public Mono<Franquicia> createFranquicia(Integer idFranquicia, String nombreFranquicia) {
+        if (idFranquicia == null) {
+            return franquiciaRepository.saveFranquicia(new Franquicia(null, nombreFranquicia));
+        }
         return franquiciaRepository.findByIdFranquicia(idFranquicia)
                 .flatMap(exists -> Mono.<Franquicia>error(new IllegalArgumentException("Ya existe una franquicia con este id: " + idFranquicia)))
-                .switchIfEmpty(franquiciaRepository.saveFranquicia(new Franquicia(idFranquicia, nombreFranquicia)))
-                ;
+                .switchIfEmpty(franquiciaRepository.saveFranquicia(new Franquicia(idFranquicia, nombreFranquicia)));
     }
 
     @Override

--- a/domain/usecase/src/main/java/co/com/franquicias/usecase/franquicia/FranquiciaUseCase.java
+++ b/domain/usecase/src/main/java/co/com/franquicias/usecase/franquicia/FranquiciaUseCase.java
@@ -2,9 +2,13 @@ package co.com.franquicias.usecase.franquicia;
 
 import co.com.franquicias.model.franquicia.Franquicia;
 import co.com.franquicias.model.franquicia.gateways.FranquiciaRepository;
+import co.com.franquicias.model.producto.Producto;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.Comparator;
+import java.util.List;
 
 @RequiredArgsConstructor
 public class FranquiciaUseCase implements IFranquiciaUseCase{
@@ -43,5 +47,23 @@ public class FranquiciaUseCase implements IFranquiciaUseCase{
         return franquiciaRepository.findByIdFranquicia(idFranquicia)
                 .switchIfEmpty(Mono.error(new IllegalArgumentException("No existe una franquicia con el id: " + idFranquicia)))
                 .flatMap(franquicia -> franquiciaRepository.deleteFranquicia(idFranquicia));
+    }
+
+    @Override
+    public Flux<Franquicia> findProductoWithMaxStockBySucursal(Integer idFranquicia) {
+        return franquiciaRepository.findByIdFranquicia(idFranquicia)
+                .filter(franquicia -> franquicia.getListaSucursales() != null)
+                .map(franquicia -> {
+                    franquicia.getListaSucursales().forEach(sucursal -> {
+                        if (sucursal.getListaProductos() != null && !sucursal.getListaProductos().isEmpty()) {
+                            Producto maxProducto = sucursal.getListaProductos().stream()
+                                    .max(Comparator.comparingInt(Producto::getStock))
+                                    .orElse(null);
+                            sucursal.setListaProductos(maxProducto != null ? List.of(maxProducto) : List.of());
+                        }
+                    });
+                    return franquicia;
+                })
+                .flux();
     }
 }

--- a/domain/usecase/src/main/java/co/com/franquicias/usecase/franquicia/IFranquiciaUseCase.java
+++ b/domain/usecase/src/main/java/co/com/franquicias/usecase/franquicia/IFranquiciaUseCase.java
@@ -10,4 +10,5 @@ public interface IFranquiciaUseCase {
     Mono<Franquicia> findByIdFranquicia(Integer idFranquicia);
     Mono<Franquicia> updateNombreFranquicia(Integer idFranquicia, String nuevoNombreFranquicia);
     Mono<Void> deleteFranquicia(Integer idFranquicia);
+    Flux<Franquicia> findProductoWithMaxStockBySucursal(Integer idFranquicia);
 }

--- a/domain/usecase/src/main/java/co/com/franquicias/usecase/producto/ProductoUseCase.java
+++ b/domain/usecase/src/main/java/co/com/franquicias/usecase/producto/ProductoUseCase.java
@@ -3,7 +3,6 @@ package co.com.franquicias.usecase.producto;
 import co.com.franquicias.model.franquicia.gateways.FranquiciaRepository;
 import co.com.franquicias.model.producto.Producto;
 import co.com.franquicias.model.producto.gateways.ProductoRepository;
-import co.com.franquicias.model.sucursal.gateways.SucursalRepository;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
 

--- a/infrastructure/driven-adapters/r2dbc-postgresql/build.gradle
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/build.gradle
@@ -1,0 +1,11 @@
+dependencies {
+    implementation project(':model')
+    implementation 'org.springframework:spring-context'
+    implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
+    implementation 'jakarta.persistence:jakarta.persistence-api' // TODO: Check if it's still necessary
+    implementation 'org.postgresql:r2dbc-postgresql'
+    implementation 'org.reactivecommons.utils:object-mapper-api:0.1.0'
+
+    testImplementation 'org.reactivecommons.utils:object-mapper:0.1.0'
+}
+

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/config/PostgreSQLConnectionPool.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/config/PostgreSQLConnectionPool.java
@@ -1,0 +1,42 @@
+package co.com.franquicias.r2dbc.config;
+
+import io.r2dbc.pool.ConnectionPool;
+import io.r2dbc.pool.ConnectionPoolConfiguration;
+import io.r2dbc.postgresql.PostgresqlConnectionConfiguration;
+import io.r2dbc.postgresql.PostgresqlConnectionFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+public class PostgreSQLConnectionPool {
+    /* Change these values for your project */
+    public static final int INITIAL_SIZE = 12;
+    public static final int MAX_SIZE = 15;
+    public static final int MAX_IDLE_TIME = 30;
+    public static final int DEFAULT_PORT = 5432;
+
+	@Bean
+	public ConnectionPool getConnectionConfig(PostgresqlConnectionProperties properties) {
+		PostgresqlConnectionConfiguration dbConfiguration = PostgresqlConnectionConfiguration.builder()
+                .host(properties.host())
+                .port(properties.port())
+                .database(properties.database())
+                .schema(properties.schema())
+                .username(properties.username())
+                .password(properties.password())
+                .build();
+
+        ConnectionPoolConfiguration poolConfiguration = ConnectionPoolConfiguration.builder()
+                .connectionFactory(new PostgresqlConnectionFactory(dbConfiguration))
+                .name("api-postgres-connection-pool")
+                .initialSize(INITIAL_SIZE)
+                .maxSize(MAX_SIZE)
+                .maxIdleTime(Duration.ofMinutes(MAX_IDLE_TIME))
+                .validationQuery("SELECT 1")
+                .build();
+
+		return new ConnectionPool(poolConfiguration);
+	}
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/config/PostgresqlConnectionProperties.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/config/PostgresqlConnectionProperties.java
@@ -1,0 +1,14 @@
+package co.com.franquicias.r2dbc.config;
+
+// TODO: Load properties from the application.yaml file or from secrets manager
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "adapters.r2dbc")
+public record PostgresqlConnectionProperties(
+        String host,
+        Integer port,
+        String database,
+        String schema,
+        String username,
+        String password) {
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/entity/FranquiciaEntity.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/entity/FranquiciaEntity.java
@@ -1,19 +1,23 @@
 package co.com.franquicias.r2dbc.entity;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 import lombok.Data;
-
-import java.util.List;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 
 @Table(name = "franquicia")
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class FranquiciaEntity {
 
     @Id
-    private String idFranquicia;
+    @Column("id_franquicia")
+    private Integer idFranquicia;
 
+    @Column("nombre_franquicia")
     private String nombreFranquicia;
 
-    private List<SucursalEntity> listaSucursales;
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/entity/FranquiciaEntity.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/entity/FranquiciaEntity.java
@@ -1,7 +1,7 @@
 package co.com.franquicias.r2dbc.entity;
 
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
 import lombok.Data;
 
 import java.util.List;

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/entity/FranquiciaEntity.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/entity/FranquiciaEntity.java
@@ -1,0 +1,19 @@
+package co.com.franquicias.r2dbc.entity;
+
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+import java.util.List;
+
+@Table(name = "franquicia")
+@Data
+public class FranquiciaEntity {
+
+    @Id
+    private String idFranquicia;
+
+    private String nombreFranquicia;
+
+    private List<SucursalEntity> listaSucursales;
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/entity/ProductoEntity.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/entity/ProductoEntity.java
@@ -1,15 +1,28 @@
 package co.com.franquicias.r2dbc.entity;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 
 @Table(name = "producto")
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class ProductoEntity {
 
     @Id
+    @Column("id_producto")
     private Integer idProducto;
+    
+    @Column("nombre_producto")
     private String nombreProducto;
+    
+    @Column("stock")
     private Integer stock;
+    
+    @Column("id_sucursal")
+    private Integer idSucursal;
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/entity/ProductoEntity.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/entity/ProductoEntity.java
@@ -1,7 +1,7 @@
 package co.com.franquicias.r2dbc.entity;
 
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
 import lombok.Data;
 
 @Table(name = "producto")

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/entity/ProductoEntity.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/entity/ProductoEntity.java
@@ -1,0 +1,15 @@
+package co.com.franquicias.r2dbc.entity;
+
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+@Table(name = "producto")
+@Data
+public class ProductoEntity {
+
+    @Id
+    private Integer idProducto;
+    private String nombreProducto;
+    private Integer stock;
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/entity/SucursalEntity.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/entity/SucursalEntity.java
@@ -1,17 +1,25 @@
 package co.com.franquicias.r2dbc.entity;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 import lombok.Data;
-
-import java.util.List;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 
 @Table(name = "sucursal")
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class SucursalEntity {
 
     @Id
+    @Column("id_sucursal")
     private Integer idSucursal;
+    
+    @Column("nombre_sucursal")
     private String nombreSucursal;
-    private List<ProductoEntity> listaProductos;
+    
+    @Column("id_franquicia")
+    private Integer idFranquicia;
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/entity/SucursalEntity.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/entity/SucursalEntity.java
@@ -1,8 +1,7 @@
 package co.com.franquicias.r2dbc.entity;
 
-import co.com.franquicias.model.producto.Producto;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
 import lombok.Data;
 
 import java.util.List;
@@ -14,5 +13,5 @@ public class SucursalEntity {
     @Id
     private Integer idSucursal;
     private String nombreSucursal;
-    private List<Producto> listaProductos;
+    private List<ProductoEntity> listaProductos;
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/entity/SucursalEntity.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/entity/SucursalEntity.java
@@ -1,0 +1,18 @@
+package co.com.franquicias.r2dbc.entity;
+
+import co.com.franquicias.model.producto.Producto;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+import java.util.List;
+
+@Table(name = "sucursal")
+@Data
+public class SucursalEntity {
+
+    @Id
+    private Integer idSucursal;
+    private String nombreSucursal;
+    private List<Producto> listaProductos;
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/franquicia/FranquiciaReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/franquicia/FranquiciaReactiveRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
 // TODO: This file is just an example, you should delete or modify it
-public interface FranquiciaReactiveRepository extends ReactiveCrudRepository<FranquiciaEntity, Integer>, ReactiveQueryByExampleExecutor<Integer> {
+public interface FranquiciaReactiveRepository extends ReactiveCrudRepository<FranquiciaEntity, Integer>, ReactiveQueryByExampleExecutor<FranquiciaEntity> {
 
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/franquicia/FranquiciaReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/franquicia/FranquiciaReactiveRepository.java
@@ -1,0 +1,10 @@
+package co.com.franquicias.r2dbc.franquicia;
+
+import co.com.franquicias.r2dbc.entity.FranquiciaEntity;
+import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+// TODO: This file is just an example, you should delete or modify it
+public interface FranquiciaReactiveRepository extends ReactiveCrudRepository<FranquiciaEntity, Integer>, ReactiveQueryByExampleExecutor<Integer> {
+
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/franquicia/FranquiciaReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/franquicia/FranquiciaReactiveRepositoryAdapter.java
@@ -3,7 +3,12 @@ package co.com.franquicias.r2dbc.franquicia;
 import co.com.franquicias.model.franquicia.Franquicia;
 import co.com.franquicias.model.franquicia.gateways.FranquiciaRepository;
 import co.com.franquicias.r2dbc.entity.FranquiciaEntity;
+import co.com.franquicias.r2dbc.entity.ProductoEntity;
 import co.com.franquicias.r2dbc.helper.ReactiveAdapterOperations;
+
+import java.util.Comparator;
+import java.util.List;
+
 import org.reactivecommons.utils.ObjectMapper;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
@@ -27,27 +32,36 @@ public class FranquiciaReactiveRepositoryAdapter extends ReactiveAdapterOperatio
 
     @Override
     public Mono<Franquicia> saveFranquicia(Franquicia franquicia) {
-        return null;
+        FranquiciaEntity entity = mapper.map(franquicia, FranquiciaEntity.class);
+        return repository.save(entity)
+                .map(saved -> mapper.map(saved, Franquicia.class));
     }
 
     @Override
     public Mono<Franquicia> findByIdFranquicia(Integer idFranquicia) {
-        return null;
+        return repository.findById(idFranquicia)
+                .map(entity -> mapper.map(entity, Franquicia.class));
     }
 
     @Override
     public Flux<Franquicia> findByAllFranquicias() {
-        return null;
+        return repository.findAll()
+                .map(entity -> mapper.map(entity, Franquicia.class));
     }
 
     @Override
     public Mono<Franquicia> updateFranquicia(Integer id, String nombreFranquicia) {
-        return null;
+        return repository.findById(id)
+                .flatMap(entity -> {
+                    entity.setNombreFranquicia(nombreFranquicia);
+                    return repository.save(entity);
+                })
+                .map(updated -> mapper.map(updated, Franquicia.class));
     }
 
     @Override
     public Mono<Void> deleteFranquicia(Integer idFranquicia) {
-        return null;
+        return repository.deleteById(idFranquicia);
     }
 
     @Override

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/franquicia/FranquiciaReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/franquicia/FranquiciaReactiveRepositoryAdapter.java
@@ -1,0 +1,57 @@
+package co.com.franquicias.r2dbc.franquicia;
+
+import co.com.franquicias.model.franquicia.Franquicia;
+import co.com.franquicias.model.franquicia.gateways.FranquiciaRepository;
+import co.com.franquicias.r2dbc.entity.FranquiciaEntity;
+import co.com.franquicias.r2dbc.helper.ReactiveAdapterOperations;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Repository
+public class FranquiciaReactiveRepositoryAdapter extends ReactiveAdapterOperations<
+        Franquicia/* change for domain model */,
+        FranquiciaEntity/* change for adapter model */,
+    Integer,
+        FranquiciaReactiveRepository
+> implements FranquiciaRepository {
+    public FranquiciaReactiveRepositoryAdapter(FranquiciaReactiveRepository repository, ObjectMapper mapper) {
+        /**
+         *  Could be use mapper.mapBuilder if your domain model implement builder pattern
+         *  super(repository, mapper, d -> mapper.mapBuilder(d,ObjectModel.ObjectModelBuilder.class).build());
+         *  Or using mapper.map with the class of the object model
+         */
+        super(repository, mapper, d -> mapper.mapBuilder(d,Franquicia.FranquiciaBuilder.class).build());
+    }
+
+    @Override
+    public Mono<Franquicia> saveFranquicia(Franquicia franquicia) {
+        return null;
+    }
+
+    @Override
+    public Mono<Franquicia> findByIdFranquicia(Integer idFranquicia) {
+        return null;
+    }
+
+    @Override
+    public Flux<Franquicia> findByAllFranquicias() {
+        return null;
+    }
+
+    @Override
+    public Mono<Franquicia> updateFranquicia(Integer id, String nombreFranquicia) {
+        return null;
+    }
+
+    @Override
+    public Mono<Void> deleteFranquicia(Integer idFranquicia) {
+        return null;
+    }
+
+    @Override
+    public Flux<Franquicia> findProductoWithMaxStockBySucursal(Integer idFranquicia) {
+        return null;
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/franquicia/FranquiciaReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/franquicia/FranquiciaReactiveRepositoryAdapter.java
@@ -2,8 +2,8 @@ package co.com.franquicias.r2dbc.franquicia;
 
 import co.com.franquicias.model.franquicia.Franquicia;
 import co.com.franquicias.model.franquicia.gateways.FranquiciaRepository;
+import co.com.franquicias.model.producto.Producto;
 import co.com.franquicias.r2dbc.entity.FranquiciaEntity;
-import co.com.franquicias.r2dbc.entity.ProductoEntity;
 import co.com.franquicias.r2dbc.helper.ReactiveAdapterOperations;
 
 import java.util.Comparator;
@@ -66,6 +66,25 @@ public class FranquiciaReactiveRepositoryAdapter extends ReactiveAdapterOperatio
 
     @Override
     public Flux<Franquicia> findProductoWithMaxStockBySucursal(Integer idFranquicia) {
-        return null;
+        return repository.findById(idFranquicia)
+            .map(entity -> {
+                if (entity.getListaSucursales() != null) {
+                    entity.getListaSucursales().forEach(sucursal -> {
+                        if (sucursal.getListaProductos() != null && !sucursal.getListaProductos().isEmpty()) {
+                            Producto maxStockProducto = sucursal.getListaProductos().stream()
+                                    .max(Comparator.comparingInt(Producto::getStock))
+                                .orElse(null);
+                            List<Producto> productosMax = maxStockProducto != null
+                                ? List.of(mapper.map(maxStockProducto, Producto.class))
+                                : List.of();
+                            sucursal.setListaProductos(productosMax);
+                        } else {
+                            sucursal.setListaProductos(List.of());
+                        }
+                    });
+                }
+                return mapper.map(entity, Franquicia.class);
+            })
+            .flux();
     }
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/helper/ReactiveAdapterOperations.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/helper/ReactiveAdapterOperations.java
@@ -1,0 +1,67 @@
+package co.com.franquicias.r2dbc.helper;
+
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.data.domain.Example;
+import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.function.Function;
+
+public abstract class ReactiveAdapterOperations<E, D, I, R extends ReactiveCrudRepository<D, I> & ReactiveQueryByExampleExecutor<D>> {
+    protected R repository;
+    protected ObjectMapper mapper;
+    private final Class<D> dataClass;
+    private final Function<D, E> toEntityFn;
+
+    @SuppressWarnings("unchecked")
+    protected ReactiveAdapterOperations(R repository, ObjectMapper mapper, Function<D, E> toEntityFn) {
+        this.repository = repository;
+        this.mapper = mapper;
+        ParameterizedType genericSuperclass = (ParameterizedType) this.getClass().getGenericSuperclass();
+        this.dataClass = (Class<D>) genericSuperclass.getActualTypeArguments()[1];
+        this.toEntityFn = toEntityFn;
+    }
+
+    protected D toData(E entity) {
+        return mapper.map(entity, dataClass);
+    }
+
+    protected E toEntity(D data) {
+        return data != null ? toEntityFn.apply(data) : null;
+    }
+
+    public Mono<E> save(E entity) {
+        return saveData(toData(entity))
+                .map(this::toEntity);
+    }
+
+    protected Flux<E> saveAllEntities(Flux<E> entities) {
+        return saveData(entities.map(this::toData))
+                .map(this::toEntity);
+    }
+
+    protected Mono<D> saveData(D data) {
+        return repository.save(data);
+    }
+
+    protected Flux<D> saveData(Flux<D> data) {
+        return repository.saveAll(data);
+    }
+
+    public Mono<E> findById(I id) {
+        return repository.findById(id).map(this::toEntity);
+    }
+
+    public Flux<E> findByExample(E entity) {
+        return repository.findAll(Example.of(toData(entity)))
+                .map(this::toEntity);
+    }
+
+    public Flux<E> findAll() {
+        return repository.findAll()
+                .map(this::toEntity);
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/producto/ProductoReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/producto/ProductoReactiveRepository.java
@@ -1,9 +1,10 @@
 package co.com.franquicias.r2dbc.producto;
 
+import co.com.franquicias.r2dbc.entity.ProductoEntity;
 import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
 // TODO: This file is just an example, you should delete or modify it
-public interface ProductoReactiveRepository extends ReactiveCrudRepository<Object, String>, ReactiveQueryByExampleExecutor<Object> {
+public interface ProductoReactiveRepository extends ReactiveCrudRepository<ProductoEntity, Integer>, ReactiveQueryByExampleExecutor<ProductoEntity> {
 
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/producto/ProductoReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/producto/ProductoReactiveRepository.java
@@ -1,0 +1,9 @@
+package co.com.franquicias.r2dbc.producto;
+
+import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+// TODO: This file is just an example, you should delete or modify it
+public interface ProductoReactiveRepository extends ReactiveCrudRepository<Object, String>, ReactiveQueryByExampleExecutor<Object> {
+
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/producto/ProductoReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/producto/ProductoReactiveRepositoryAdapter.java
@@ -1,0 +1,23 @@
+package co.com.franquicias.r2dbc.producto;
+
+import co.com.franquicias.r2dbc.helper.ReactiveAdapterOperations;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ProductoReactiveRepositoryAdapter extends ReactiveAdapterOperations<
+    Object/* change for domain model */,
+    Object/* change for adapter model */,
+    String,
+        ProductoReactiveRepository
+> {
+    public ProductoReactiveRepositoryAdapter(ProductoReactiveRepository repository, ObjectMapper mapper) {
+        /**
+         *  Could be use mapper.mapBuilder if your domain model implement builder pattern
+         *  super(repository, mapper, d -> mapper.mapBuilder(d,ObjectModel.ObjectModelBuilder.class).build());
+         *  Or using mapper.map with the class of the object model
+         */
+        super(repository, mapper, d -> mapper.map(d, Object.class/* change for domain model */));
+    }
+
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/producto/ProductoReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/producto/ProductoReactiveRepositoryAdapter.java
@@ -1,23 +1,46 @@
 package co.com.franquicias.r2dbc.producto;
 
+import co.com.franquicias.model.producto.Producto;
+import co.com.franquicias.model.producto.gateways.ProductoRepository;
+import co.com.franquicias.r2dbc.entity.ProductoEntity;
 import co.com.franquicias.r2dbc.helper.ReactiveAdapterOperations;
 import org.reactivecommons.utils.ObjectMapper;
 import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
 
 @Repository
 public class ProductoReactiveRepositoryAdapter extends ReactiveAdapterOperations<
-    Object/* change for domain model */,
-    Object/* change for adapter model */,
-    String,
+        Producto/* change for domain model */,
+        ProductoEntity/* change for adapter model */,
+    Integer,
         ProductoReactiveRepository
-> {
+> implements ProductoRepository {
     public ProductoReactiveRepositoryAdapter(ProductoReactiveRepository repository, ObjectMapper mapper) {
         /**
          *  Could be use mapper.mapBuilder if your domain model implement builder pattern
          *  super(repository, mapper, d -> mapper.mapBuilder(d,ObjectModel.ObjectModelBuilder.class).build());
          *  Or using mapper.map with the class of the object model
          */
-        super(repository, mapper, d -> mapper.map(d, Object.class/* change for domain model */));
+        super(repository, mapper, d -> mapper.mapBuilder(d,Producto.ProductoBuilder.class).build());
     }
 
+    @Override
+    public Mono<Producto> saveProducto(Integer idFranquicia, Integer idSucursal, Integer idProducto, String nombreProducto, Integer stock) {
+        return null;
+    }
+
+    @Override
+    public Mono<Producto> updateNombreProducto(Integer idFranquicia, Integer idSucursal, Integer idProducto, String nuevoNombreProducto) {
+        return null;
+    }
+
+    @Override
+    public Mono<Producto> updateStockProducto(Integer idFranquicia, Integer idSucursal, Integer idProducto, Integer stock) {
+        return null;
+    }
+
+    @Override
+    public Mono<Void> deleteProducto(Integer idFranquicia, Integer idSucursal, Integer idProducto) {
+        return null;
+    }
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/producto/ProductoReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/producto/ProductoReactiveRepositoryAdapter.java
@@ -2,7 +2,9 @@ package co.com.franquicias.r2dbc.producto;
 
 import co.com.franquicias.model.producto.Producto;
 import co.com.franquicias.model.producto.gateways.ProductoRepository;
+import co.com.franquicias.model.sucursal.Sucursal;
 import co.com.franquicias.r2dbc.entity.ProductoEntity;
+import co.com.franquicias.r2dbc.entity.SucursalEntity;
 import co.com.franquicias.r2dbc.helper.ReactiveAdapterOperations;
 import org.reactivecommons.utils.ObjectMapper;
 import org.springframework.stereotype.Repository;
@@ -26,21 +28,36 @@ public class ProductoReactiveRepositoryAdapter extends ReactiveAdapterOperations
 
     @Override
     public Mono<Producto> saveProducto(Integer idFranquicia, Integer idSucursal, Integer idProducto, String nombreProducto, Integer stock) {
-        return null;
+        ProductoEntity entity = new ProductoEntity();
+        entity.setIdProducto(idProducto);
+        entity.setNombreProducto(nombreProducto);
+        entity.setStock(stock);
+        return repository.save(entity)
+                .map(saved -> mapper.map(saved, Producto.class));
     }
 
     @Override
     public Mono<Producto> updateNombreProducto(Integer idFranquicia, Integer idSucursal, Integer idProducto, String nuevoNombreProducto) {
-        return null;
+        return repository.findById(idProducto)
+                .flatMap(entity -> {
+                    entity.setNombreProducto(nuevoNombreProducto);
+                    return repository.save(entity);
+                })
+                .map(updated -> mapper.map(updated, Producto.class));
     }
 
     @Override
     public Mono<Producto> updateStockProducto(Integer idFranquicia, Integer idSucursal, Integer idProducto, Integer stock) {
-        return null;
+        return repository.findById(idProducto)
+                .flatMap(entity -> {
+                    entity.setStock(stock);
+                    return repository.save(entity);
+                })
+                .map(updated -> mapper.map(updated, Producto.class));
     }
 
     @Override
     public Mono<Void> deleteProducto(Integer idFranquicia, Integer idSucursal, Integer idProducto) {
-        return null;
+        return repository.deleteById(idProducto);
     }
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/sucursal/SucursalReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/sucursal/SucursalReactiveRepository.java
@@ -1,9 +1,10 @@
 package co.com.franquicias.r2dbc.sucursal;
 
+import co.com.franquicias.r2dbc.entity.SucursalEntity;
 import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
 // TODO: This file is just an example, you should delete or modify it
-public interface SucursalReactiveRepository extends ReactiveCrudRepository<Object, String>, ReactiveQueryByExampleExecutor<Object> {
+public interface SucursalReactiveRepository extends ReactiveCrudRepository<SucursalEntity, Integer>, ReactiveQueryByExampleExecutor<SucursalEntity> {
 
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/sucursal/SucursalReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/sucursal/SucursalReactiveRepository.java
@@ -1,0 +1,9 @@
+package co.com.franquicias.r2dbc.sucursal;
+
+import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+// TODO: This file is just an example, you should delete or modify it
+public interface SucursalReactiveRepository extends ReactiveCrudRepository<Object, String>, ReactiveQueryByExampleExecutor<Object> {
+
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/sucursal/SucursalReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/sucursal/SucursalReactiveRepositoryAdapter.java
@@ -26,11 +26,20 @@ public class SucursalReactiveRepositoryAdapter extends ReactiveAdapterOperations
 
     @Override
     public Mono<Sucursal> saveSucursal(Integer idFranquicia, Integer idSucursal, String nombreSucursal) {
-        return null;
+        SucursalEntity entity = new SucursalEntity();
+        entity.setIdSucursal(idSucursal);
+        entity.setNombreSucursal(nombreSucursal);
+        return repository.save(entity)
+                .map(saved -> mapper.map(saved, Sucursal.class));
     }
 
     @Override
     public Mono<Sucursal> updateSucursal(Integer idFranquicia, Integer idSucursal, String nuevoNombre) {
-        return null;
+        return repository.findById(idSucursal)
+                .flatMap(entity -> {
+                    entity.setNombreSucursal(nuevoNombre);
+                    return repository.save(entity);
+                })
+                .map(updated -> mapper.map(updated, Sucursal.class));
     }
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/sucursal/SucursalReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/sucursal/SucursalReactiveRepositoryAdapter.java
@@ -1,0 +1,23 @@
+package co.com.franquicias.r2dbc.sucursal;
+
+import co.com.franquicias.r2dbc.helper.ReactiveAdapterOperations;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class SucursalReactiveRepositoryAdapter extends ReactiveAdapterOperations<
+    Object/* change for domain model */,
+    Object/* change for adapter model */,
+    String,
+        SucursalReactiveRepository
+> {
+    public SucursalReactiveRepositoryAdapter(SucursalReactiveRepository repository, ObjectMapper mapper) {
+        /**
+         *  Could be use mapper.mapBuilder if your domain model implement builder pattern
+         *  super(repository, mapper, d -> mapper.mapBuilder(d,ObjectModel.ObjectModelBuilder.class).build());
+         *  Or using mapper.map with the class of the object model
+         */
+        super(repository, mapper, d -> mapper.map(d, Object.class/* change for domain model */));
+    }
+
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/sucursal/SucursalReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/sucursal/SucursalReactiveRepositoryAdapter.java
@@ -1,23 +1,36 @@
 package co.com.franquicias.r2dbc.sucursal;
 
+import co.com.franquicias.model.sucursal.Sucursal;
+import co.com.franquicias.model.sucursal.gateways.SucursalRepository;
+import co.com.franquicias.r2dbc.entity.SucursalEntity;
 import co.com.franquicias.r2dbc.helper.ReactiveAdapterOperations;
 import org.reactivecommons.utils.ObjectMapper;
 import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
 
 @Repository
 public class SucursalReactiveRepositoryAdapter extends ReactiveAdapterOperations<
-    Object/* change for domain model */,
-    Object/* change for adapter model */,
-    String,
+        Sucursal/* change for domain model */,
+        SucursalEntity/* change for adapter model */,
+    Integer,
         SucursalReactiveRepository
-> {
+> implements SucursalRepository {
     public SucursalReactiveRepositoryAdapter(SucursalReactiveRepository repository, ObjectMapper mapper) {
         /**
          *  Could be use mapper.mapBuilder if your domain model implement builder pattern
          *  super(repository, mapper, d -> mapper.mapBuilder(d,ObjectModel.ObjectModelBuilder.class).build());
          *  Or using mapper.map with the class of the object model
          */
-        super(repository, mapper, d -> mapper.map(d, Object.class/* change for domain model */));
+        super(repository, mapper, d -> mapper.mapBuilder(d,Sucursal.SucursalBuilder.class).build());
     }
 
+    @Override
+    public Mono<Sucursal> saveSucursal(Integer idFranquicia, Integer idSucursal, String nombreSucursal) {
+        return null;
+    }
+
+    @Override
+    public Mono<Sucursal> updateSucursal(Integer idFranquicia, Integer idSucursal, String nuevoNombre) {
+        return null;
+    }
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/franquicias/r2dbc/MyReactiveRepositoryAdapterTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/franquicias/r2dbc/MyReactiveRepositoryAdapterTest.java
@@ -1,0 +1,80 @@
+package co.com.franquicias.r2dbc;
+
+import co.com.franquicias.r2dbc.producto.ProductoReactiveRepository;
+import co.com.franquicias.r2dbc.producto.ProductoReactiveRepositoryAdapter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.data.domain.Example;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MyReactiveRepositoryAdapterTest {
+    // TODO: change four you own tests
+
+    @InjectMocks
+    ProductoReactiveRepositoryAdapter repositoryAdapter;
+
+    @Mock
+    ProductoReactiveRepository repository;
+
+    @Mock
+    ObjectMapper mapper;
+
+    @Test
+    void mustFindValueById() {
+
+        when(repository.findById("1")).thenReturn(Mono.just("test"));
+        when(mapper.map("test", Object.class)).thenReturn("test");
+
+        Mono<Object> result = repositoryAdapter.findById("1");
+
+        StepVerifier.create(result)
+                .expectNextMatches(value -> value.equals("test"))
+                .verifyComplete();
+    }
+
+    @Test
+    void mustFindAllValues() {
+        when(repository.findAll()).thenReturn(Flux.just("test"));
+        when(mapper.map("test", Object.class)).thenReturn("test");
+
+        Flux<Object> result = repositoryAdapter.findAll();
+
+        StepVerifier.create(result)
+                .expectNextMatches(value -> value.equals("test"))
+                .verifyComplete();
+    }
+
+    @Test
+    void mustFindByExample() {
+        when(repository.findAll(any(Example.class))).thenReturn(Flux.just("test"));
+        when(mapper.map("test", Object.class)).thenReturn("test");
+
+        Flux<Object> result = repositoryAdapter.findByExample("test");
+
+        StepVerifier.create(result)
+                .expectNextMatches(value -> value.equals("test"))
+                .verifyComplete();
+    }
+
+    @Test
+    void mustSaveValue() {
+        when(repository.save("test")).thenReturn(Mono.just("test"));
+        when(mapper.map("test", Object.class)).thenReturn("test");
+
+        Mono<Object> result = repositoryAdapter.save("test");
+
+        StepVerifier.create(result)
+                .expectNextMatches(value -> value.equals("test"))
+                .verifyComplete();
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/franquicias/r2dbc/config/PostgreSQLConnectionPoolTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/franquicias/r2dbc/config/PostgreSQLConnectionPoolTest.java
@@ -1,0 +1,37 @@
+package co.com.franquicias.r2dbc.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+class PostgreSQLConnectionPoolTest {
+
+    @InjectMocks
+    private PostgreSQLConnectionPool connectionPool;
+
+    @Mock
+    private PostgresqlConnectionProperties properties;
+
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        when(properties.host()).thenReturn("localhost");
+        when(properties.port()).thenReturn(5432);
+        when(properties.database()).thenReturn("dbName");
+        when(properties.schema()).thenReturn("schema");
+        when(properties.username()).thenReturn("username");
+        when(properties.password()).thenReturn("password");
+    }
+
+    @Test
+    void getConnectionConfigSuccess() {
+        assertNotNull(connectionPool.getConnectionConfig(properties));
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/franquicias/r2dbc/helper/ReactiveAdapterOperationsTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/franquicias/r2dbc/helper/ReactiveAdapterOperationsTest.java
@@ -1,0 +1,168 @@
+package co.com.franquicias.r2dbc.helper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.data.domain.Example;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Objects;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class ReactiveAdapterOperationsTest {
+
+    private DummyRepository repository;
+    private ObjectMapper mapper;
+    private ReactiveAdapterOperations<DummyEntity, DummyData, String, DummyRepository> operations;
+
+    @BeforeEach
+    void setUp() {
+        repository = Mockito.mock(DummyRepository.class);
+        mapper = Mockito.mock(ObjectMapper.class);
+        operations = new ReactiveAdapterOperations<DummyEntity, DummyData, String, DummyRepository>(
+                repository, mapper, DummyEntity::toEntity) {};
+    }
+
+    @Test
+    void save() {
+        DummyEntity entity = new DummyEntity("1", "test");
+        DummyData data = new DummyData("1", "test");
+
+        when(mapper.map(entity, DummyData.class)).thenReturn(data);
+        when(repository.save(data)).thenReturn(Mono.just(data));
+
+        StepVerifier.create(operations.save(entity))
+                .expectNext(entity)
+                .verifyComplete();
+    }
+
+    @Test
+    void saveAllEntities() {
+        DummyEntity entity1 = new DummyEntity("1", "test1");
+        DummyEntity entity2 = new DummyEntity("2", "test2");
+        DummyData data1 = new DummyData("1", "test1");
+        DummyData data2 = new DummyData("2", "test2");
+
+        when(mapper.map(entity1, DummyData.class)).thenReturn(data1);
+        when(mapper.map(entity2, DummyData.class)).thenReturn(data2);
+        when(repository.saveAll(any(Flux.class))).thenReturn(Flux.just(data1, data2));
+
+        StepVerifier.create(operations.saveAllEntities(Flux.just(entity1, entity2)))
+                .expectNext(entity1, entity2)
+                .verifyComplete();
+    }
+
+    @Test
+    void findById() {
+        DummyData data = new DummyData("1", "test");
+        DummyEntity entity = new DummyEntity("1", "test");
+
+        when(repository.findById("1")).thenReturn(Mono.just(data));
+
+        StepVerifier.create(operations.findById("1"))
+                .expectNext(entity)
+                .verifyComplete();
+    }
+
+    @Test
+    void findByExample() {
+        DummyEntity entity = new DummyEntity("1", "test");
+        DummyData data = new DummyData("1", "test");
+
+        when(mapper.map(entity, DummyData.class)).thenReturn(data);
+        when(repository.findAll(any(Example.class))).thenReturn(Flux.just(data));
+
+        StepVerifier.create(operations.findByExample(entity))
+                .expectNext(entity)
+                .verifyComplete();
+    }
+
+    @Test
+    void findAll() {
+        DummyData data1 = new DummyData("1", "test1");
+        DummyData data2 = new DummyData("2", "test2");
+        DummyEntity entity1 = new DummyEntity("1", "test1");
+        DummyEntity entity2 = new DummyEntity("2", "test2");
+
+        when(repository.findAll()).thenReturn(Flux.just(data1, data2));
+
+        StepVerifier.create(operations.findAll())
+                .expectNext(entity1, entity2)
+                .verifyComplete();
+    }
+
+    static class DummyEntity {
+        private String id;
+        private String name;
+
+        public DummyEntity(String id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public static DummyEntity toEntity(DummyData data) {
+            return new DummyEntity(data.getId(), data.getName());
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            DummyEntity that = (DummyEntity) o;
+            return id.equals(that.id) && name.equals(that.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, name);
+        }
+    }
+
+    static class DummyData {
+        private String id;
+        private String name;
+
+        public DummyData(String id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            DummyData that = (DummyData) o;
+            return id.equals(that.id) && name.equals(that.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, name);
+        }
+    }
+
+    interface DummyRepository extends ReactiveCrudRepository<DummyData, String>, ReactiveQueryByExampleExecutor<DummyData> {}
+}

--- a/infrastructure/entry-points/reactive-web/build.gradle
+++ b/infrastructure/entry-points/reactive-web/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    implementation project(':usecase')
+    implementation project(':model')
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/FranquiciaHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/FranquiciaHandler.java
@@ -1,0 +1,13 @@
+package co.com.franquicias.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class FranquiciaHandler {
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/FranquiciaRouter.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/FranquiciaRouter.java
@@ -1,0 +1,15 @@
+package co.com.franquicias.api;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
+import static org.springframework.web.reactive.function.server.RequestPredicates.POST;
+import static org.springframework.web.reactive.function.server.RouterFunctions.route;
+
+@Configuration
+public class FranquiciaRouter {
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/config/CorsConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/config/CorsConfig.java
@@ -1,0 +1,29 @@
+package co.com.franquicias.api.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsWebFilter;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    CorsWebFilter corsWebFilter(@Value("${cors.allowed-origins}") String origins) {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.setAllowedOrigins(List.of(origins.split(",")));
+        config.setAllowedMethods(Arrays.asList("POST", "GET")); // TODO: Check others required methods
+        config.setAllowedHeaders(List.of(CorsConfiguration.ALL));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return new CorsWebFilter(source);
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/config/SecurityHeadersConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/config/SecurityHeadersConfig.java
@@ -1,0 +1,25 @@
+package co.com.franquicias.api.config;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+@Component
+public class SecurityHeadersConfig implements WebFilter {
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        HttpHeaders headers = exchange.getResponse().getHeaders();
+        headers.set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'self'; form-action 'self'");
+        headers.set("Strict-Transport-Security", "max-age=31536000;");
+        headers.set("X-Content-Type-Options", "nosniff");
+        headers.set("Server", "");
+        headers.set("Cache-Control", "no-store");
+        headers.set("Pragma", "no-cache");
+        headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+        return chain.filter(exchange);
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/franquicia/FranquiciaHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/franquicia/FranquiciaHandler.java
@@ -1,4 +1,4 @@
-package co.com.franquicias.api;
+package co.com.franquicias.api.franquicia;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/franquicia/FranquiciaRouter.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/franquicia/FranquiciaRouter.java
@@ -1,4 +1,4 @@
-package co.com.franquicias.api;
+package co.com.franquicias.api.franquicia;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/producto/ProductoHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/producto/ProductoHandler.java
@@ -1,0 +1,10 @@
+package co.com.franquicias.api.producto;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProductoHandler {
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/producto/ProductoRouter.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/producto/ProductoRouter.java
@@ -1,0 +1,8 @@
+package co.com.franquicias.api.producto;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ProductoRouter {
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/sucursal/SucursalHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/sucursal/SucursalHandler.java
@@ -1,0 +1,10 @@
+package co.com.franquicias.api.sucursal;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SucursalHandler {
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/sucursal/SucursalRouter.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/sucursal/SucursalRouter.java
@@ -1,0 +1,8 @@
+package co.com.franquicias.api.sucursal;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SucursalRouter {
+
+}

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/franquicias/api/config/ConfigTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/franquicias/api/config/ConfigTest.java
@@ -1,0 +1,36 @@
+package co.com.franquicias.api.config;
+
+import co.com.franquicias.api.FranquiciaHandler;
+import co.com.franquicias.api.FranquiciaRouter;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@ContextConfiguration(classes = {FranquiciaRouter.class, FranquiciaHandler.class})
+@WebFluxTest
+@Import({CorsConfig.class, SecurityHeadersConfig.class})
+class ConfigTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Test
+    void corsConfigurationShouldAllowOrigins() {
+        webTestClient.get()
+                .uri("/api/usecase/path")
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().valueEquals("Content-Security-Policy",
+                        "default-src 'self'; frame-ancestors 'self'; form-action 'self'")
+                .expectHeader().valueEquals("Strict-Transport-Security", "max-age=31536000;")
+                .expectHeader().valueEquals("X-Content-Type-Options", "nosniff")
+                .expectHeader().valueEquals("Server", "")
+                .expectHeader().valueEquals("Cache-Control", "no-store")
+                .expectHeader().valueEquals("Pragma", "no-cache")
+                .expectHeader().valueEquals("Referrer-Policy", "strict-origin-when-cross-origin");
+    }
+
+}

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/franquicias/api/config/ConfigTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/franquicias/api/config/ConfigTest.java
@@ -1,7 +1,7 @@
 package co.com.franquicias.api.config;
 
-import co.com.franquicias.api.FranquiciaHandler;
-import co.com.franquicias.api.FranquiciaRouter;
+import co.com.franquicias.api.franquicia.FranquiciaHandler;
+import co.com.franquicias.api.franquicia.FranquiciaRouter;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,3 +22,5 @@ project(':model').projectDir = file('./domain/model')
 project(':usecase').projectDir = file('./domain/usecase')
 include ':r2dbc-postgresql'
 project(':r2dbc-postgresql').projectDir = file('./infrastructure/driven-adapters/r2dbc-postgresql')
+include ':reactive-web'
+project(':reactive-web').projectDir = file('./infrastructure/entry-points/reactive-web')

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,3 +20,5 @@ include ':usecase'
 project(':app-service').projectDir = file('./applications/app-service')
 project(':model').projectDir = file('./domain/model')
 project(':usecase').projectDir = file('./domain/usecase')
+include ':r2dbc-postgresql'
+project(':r2dbc-postgresql').projectDir = file('./infrastructure/driven-adapters/r2dbc-postgresql')


### PR DESCRIPTION
This pull request introduces significant improvements to the backend architecture by integrating reactive PostgreSQL database support, updating configuration, and enhancing domain and use case logic. The most important changes are grouped below by theme.

**Infrastructure: Reactive PostgreSQL Integration**

* Added a new `r2dbc-postgresql` adapter, including connection pool configuration (`PostgreSQLConnectionPool.java`), connection properties (`PostgresqlConnectionProperties.java`), and entity definitions for `Franquicia`, `Sucursal`, and `Producto` (`FranquiciaEntity.java`, `SucursalEntity.java`, `ProductoEntity.java`). This enables reactive database operations and aligns entities with database tables. [[1]](diffhunk://#diff-9ba63fa70507225e3f22f2b8a78994b63ff5e5296ad0074d21afb5020a1b6097R1-R42) [[2]](diffhunk://#diff-677334c99bef105d8a616ac397fa11b7827f852d9dab0bb2208c6e8794286617R1-R14) [[3]](diffhunk://#diff-5369fe8b0c7dd1df269a91ff018e569a1c68619df56a0182ce207035da55cf4dR1-R23) [[4]](diffhunk://#diff-384992434df85c46c9533fbb529e81efa4b4bd19efc03b314e1470014b4fac0bR1-R25) [[5]](diffhunk://#diff-482cb0226a9a8a30c586512b2c0eebfb298cffc7123161d1afacfa2a7972001eR1-R28)
* Implemented `FranquiciaReactiveRepositoryAdapter` to bridge domain models and database entities, supporting CRUD and a new query for products with maximum stock per branch.
* Added example reactive repository interface (`FranquiciaReactiveRepository.java`).
* Updated Gradle dependencies to include R2DBC, Spring Data R2DBC, and object mapper utilities in both the application and adapter modules. [[1]](diffhunk://#diff-c12d4e3dc5ae9501cce83cc7f4be8a94d0d975587ebd7e6a2ec3856ceeef3665R4-R6) [[2]](diffhunk://#diff-1589eed3c5d0a0df4315d2d2d37a001e91c061b234f081585883d640e3d87fcbR1-R11)

**Configuration and Environment**

* Added a Docker Compose file to provision a PostgreSQL database for local development, with environment variables and network configuration.
* Updated `application.yaml` to configure R2DBC connection properties, CORS, management endpoints, and Swagger documentation paths.
* Introduced a configuration class and test for the object mapper bean, ensuring proper mapping between domain and entity objects. [[1]](diffhunk://#diff-0a2d115472fb970929648e1887bb0e5e8fd2ee6b9a6f78d17f4bd99c43d35d9cR1-R16) [[2]](diffhunk://#diff-26fda25070924c5aa7186c9f6bf1fa7edf88a7d86f597b8bd76b83dbdc2df615R1-R20)

**Domain and Use Case Enhancements**

* Updated the `Franquicia` domain model to use `@NoArgsConstructor` and initialize the branch list in the constructor, improving compatibility with persistence frameworks and object mapping. [[1]](diffhunk://#diff-484d69caae63d0e00b94e5476169bbdc9972f589c5d9b0e90950895a4cd9b838L6-R14) [[2]](diffhunk://#diff-484d69caae63d0e00b94e5476169bbdc9972f589c5d9b0e90950895a4cd9b838R23-R25)
* Enhanced the `FranquiciaUseCase` to handle creation with or without an ID, and added a new method to retrieve, for a given franchise, the product with the highest stock in each branch. This method is now part of the use case interface. [[1]](diffhunk://#diff-9b77c63c9e5eb38e0d99981d7c0a28a0ffa8e0af7316b4b488a74741ceff7c34R5-R24) [[2]](diffhunk://#diff-9b77c63c9e5eb38e0d99981d7c0a28a0ffa8e0af7316b4b488a74741ceff7c34R53-R70) [[3]](diffhunk://#diff-f6803766d0ec44b4f64290351121bd40ba457e995ecee71e7d6bfafe876076caR13)
* Minor cleanup in `ProductoUseCase` by removing unused imports.

These changes collectively provide the foundation for reactive data access, improved configuration management, and expanded business logic for franchise and product operations.