### PR TITLE
Feature fix sucursal usecase

### DIFF
--- a/domain/model/src/main/java/co/com/franquicias/model/sucursal/Sucursal.java
+++ b/domain/model/src/main/java/co/com/franquicias/model/sucursal/Sucursal.java
@@ -15,6 +15,7 @@ import java.util.List;
 public class Sucursal {
     private Integer idSucursal;
     private String nombreSucursal;
+    private Integer idFranquicia;
     private List<Producto> listaProductos;
 
     public Sucursal(Integer idSucursal, String nombreSucursal) {}

--- a/domain/model/src/main/java/co/com/franquicias/model/sucursal/gateways/SucursalRepository.java
+++ b/domain/model/src/main/java/co/com/franquicias/model/sucursal/gateways/SucursalRepository.java
@@ -5,6 +5,7 @@ import reactor.core.publisher.Mono;
 
 public interface SucursalRepository {
     Mono<Sucursal> saveSucursal(Integer idFranquicia, Integer idSucursal, String nombreSucursal);
-    Mono<Sucursal> updateSucursal(Integer idFranquicia, Integer idSucursal, String nuevoNombre);
+    Mono<Sucursal> updateSucursal(Integer idSucursal, String nuevoNombre);
+    Mono<Sucursal> findByIdSucursal(Integer idSucursal);
 
 }

--- a/domain/usecase/src/main/java/co/com/franquicias/usecase/sucursal/ISucursalUseCase.java
+++ b/domain/usecase/src/main/java/co/com/franquicias/usecase/sucursal/ISucursalUseCase.java
@@ -6,4 +6,5 @@ import reactor.core.publisher.Mono;
 public interface ISucursalUseCase {
     Mono<Sucursal> createSucursal(Integer idFranquicia,Integer idSucursal, String nombreSucursal);
     Mono<Sucursal> updateNombreSucursal(Integer idFranquicia, Integer idSucursal, String nuevoNombreSucursal);
+    Mono<Sucursal> findByIdSucursal(Integer idFranquicia, Integer IdSucursal);
 }

--- a/domain/usecase/src/main/java/co/com/franquicias/usecase/sucursal/SucursalUseCase.java
+++ b/domain/usecase/src/main/java/co/com/franquicias/usecase/sucursal/SucursalUseCase.java
@@ -22,6 +22,14 @@ public class SucursalUseCase implements ISucursalUseCase{
     public Mono<Sucursal> updateNombreSucursal(Integer idFranquicia, Integer idSucursal, String nuevoNombreSucursal) {
         return franquiciaRepository.findByIdFranquicia(idFranquicia)
                 .switchIfEmpty(Mono.error(new IllegalArgumentException("No existe una franquicia con el id: " + idFranquicia)))
-                .flatMap(franquicia -> sucursalRepository.updateSucursal(idFranquicia, idSucursal, nuevoNombreSucursal));
+                .flatMap(franquicia -> sucursalRepository.updateSucursal(idSucursal, nuevoNombreSucursal));
+    }
+
+    @Override
+    public Mono<Sucursal> findByIdSucursal(Integer idFranquicia, Integer IdSucursal) {
+        return franquiciaRepository.findByIdFranquicia(idFranquicia)
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("No existe una franquicia con el id: " + idFranquicia)))
+                .flatMap(sucursal -> sucursalRepository.findByIdSucursal(IdSucursal))
+                ;
     }
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/sucursal/SucursalReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/sucursal/SucursalReactiveRepositoryAdapter.java
@@ -8,6 +8,8 @@ import org.reactivecommons.utils.ObjectMapper;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Mono;
 
+import java.util.ArrayList;
+
 @Repository
 public class SucursalReactiveRepositoryAdapter extends ReactiveAdapterOperations<
         Sucursal/* change for domain model */,
@@ -34,12 +36,24 @@ public class SucursalReactiveRepositoryAdapter extends ReactiveAdapterOperations
     }
 
     @Override
-    public Mono<Sucursal> updateSucursal(Integer idFranquicia, Integer idSucursal, String nuevoNombre) {
+    public Mono<Sucursal> updateSucursal(Integer idSucursal, String nuevoNombre) {
         return repository.findById(idSucursal)
                 .flatMap(entity -> {
                     entity.setNombreSucursal(nuevoNombre);
                     return repository.save(entity);
                 })
                 .map(updated -> mapper.map(updated, Sucursal.class));
+    }
+
+    @Override
+    public Mono<Sucursal> findByIdSucursal(Integer idSucursal) {
+        return repository.findById(idSucursal)
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("Sucursal no encontrada con id: " + idSucursal)))
+                .map(entity -> Sucursal.builder()
+                        .idSucursal(entity.getIdSucursal())
+                        .nombreSucursal(entity.getNombreSucursal())
+                        .idFranquicia(entity.getIdFranquicia())
+                        .listaProductos(new ArrayList<>())
+                .build());
     }
 }


### PR DESCRIPTION
This pull request introduces enhancements to the Sucursal (branch) domain model and repository interfaces, focusing on simplifying the update logic and adding the ability to fetch a Sucursal by its ID. The main changes are the addition of the `findByIdSucursal` method across layers, removal of unnecessary parameters in update methods, and a minor update to the domain model.

**Repository and Use Case API Improvements:**

* Added the `findByIdSucursal` method to the `SucursalRepository` interface, its implementation in `SucursalReactiveRepositoryAdapter`, and exposed it through the use case layer (`ISucursalUseCase` and `SucursalUseCase`). This enables fetching a branch by its ID. [[1]](diffhunk://#diff-39df48530e45c931da68bb1eed25c0c81eafaa5f802b67a159c2464a5912321fL8-R9) [[2]](diffhunk://#diff-604a9e2224fcd6f8719e07eff5afe4d59de13512ce96156ea6cadc9a508681ccR9) [[3]](diffhunk://#diff-08e562782e9785b4b52ec3feeff51a698dedd6e3fd8df579fd1019db529713acL25-R33) [[4]](diffhunk://#diff-3a5a97367ac2b7fec90abd7b82fd84894fa564cba851eb24b3ac3aed1187e4f3L37-R58)
* Simplified the `updateSucursal` method by removing the `idFranquicia` parameter from the repository and adapter layers, making updates depend only on the branch ID and new name. [[1]](diffhunk://#diff-39df48530e45c931da68bb1eed25c0c81eafaa5f802b67a159c2464a5912321fL8-R9) [[2]](diffhunk://#diff-08e562782e9785b4b52ec3feeff51a698dedd6e3fd8df579fd1019db529713acL25-R33) [[3]](diffhunk://#diff-3a5a97367ac2b7fec90abd7b82fd84894fa564cba851eb24b3ac3aed1187e4f3L37-R58)

**Domain Model Enhancement:**

* Added the `idFranquicia` field to the `Sucursal` class to better represent the relationship between a branch and its franchise.

**Implementation Details:**

* The adapter's implementation of `findByIdSucursal` constructs a new `Sucursal` instance with an empty product list if found, or throws an error if not.
* Minor import cleanups and the addition of `ArrayList` for product list initialization in the adapter.