### PR TITLE
Feature implement route producto

### DIFF
--- a/applications/app-service/src/main/java/co/com/franquicias/config/UseCasesConfig.java
+++ b/applications/app-service/src/main/java/co/com/franquicias/config/UseCasesConfig.java
@@ -36,8 +36,9 @@ public class UseCasesConfig {
         @Bean
         public ProductoUseCase productoUseCase(
                 FranquiciaRepository franquiciaRepository,
-                ProductoRepository productoRepository
+                ProductoRepository productoRepository,
+                SucursalRepository sucursalRepository
         ){
-                return new ProductoUseCase(franquiciaRepository, productoRepository);
+                return new ProductoUseCase(franquiciaRepository, productoRepository, sucursalRepository);
         }
 }

--- a/domain/model/src/main/java/co/com/franquicias/model/producto/Producto.java
+++ b/domain/model/src/main/java/co/com/franquicias/model/producto/Producto.java
@@ -2,16 +2,17 @@ package co.com.franquicias.model.producto;
 import lombok.Builder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-//import lombok.NoArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
-//@NoArgsConstructor
+@NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
 public class Producto {
     private Integer idProducto;
     private String nombreProducto;
     private Integer stock;
+    private Integer idSucursal;
 }

--- a/domain/model/src/main/java/co/com/franquicias/model/producto/gateways/ProductoRepository.java
+++ b/domain/model/src/main/java/co/com/franquicias/model/producto/gateways/ProductoRepository.java
@@ -4,9 +4,10 @@ import co.com.franquicias.model.producto.Producto;
 import reactor.core.publisher.Mono;
 
 public interface ProductoRepository {
-    Mono<Producto> saveProducto(Integer idFranquicia, Integer idSucursal, Integer idProducto, String nombreProducto, Integer stock);
-    Mono<Producto> updateNombreProducto(Integer idFranquicia, Integer idSucursal, Integer idProducto, String nuevoNombreProducto);
-    Mono<Producto> updateStockProducto(Integer idFranquicia, Integer idSucursal, Integer idProducto, Integer stock);
-    Mono<Void> deleteProducto(Integer idFranquicia, Integer idSucursal, Integer idProducto);
+    Mono<Producto> saveProducto(Integer IdSucursal,Integer idProducto, String nombreProducto, Integer stock);
+    Mono<Producto> updateNombreProducto(Integer idProducto, String nuevoNombreProducto);
+    Mono<Producto> updateStockProducto( Integer idProducto, Integer stock);
+    Mono<Void> deleteProducto(Integer idProducto);
+
 
 }

--- a/domain/usecase/src/main/java/co/com/franquicias/usecase/producto/ProductoUseCase.java
+++ b/domain/usecase/src/main/java/co/com/franquicias/usecase/producto/ProductoUseCase.java
@@ -3,6 +3,7 @@ package co.com.franquicias.usecase.producto;
 import co.com.franquicias.model.franquicia.gateways.FranquiciaRepository;
 import co.com.franquicias.model.producto.Producto;
 import co.com.franquicias.model.producto.gateways.ProductoRepository;
+import co.com.franquicias.model.sucursal.gateways.SucursalRepository;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
 
@@ -11,17 +12,15 @@ public class ProductoUseCase implements IProductoUseCase {
 
     private final FranquiciaRepository franquiciaRepository;
     private final ProductoRepository productoRepository;
+    private final SucursalRepository sucursalRepository;
     @Override
     public Mono<Producto> createProducto(Integer idFranquicia, Integer idSucursal, Integer idProducto, String nombreProducto, Integer stock) {
         return franquiciaRepository.findByIdFranquicia(idFranquicia)
                 .switchIfEmpty(Mono.error(new IllegalArgumentException("No existe una franquicia con el id: " + idFranquicia)))
-                .flatMap(franquicia -> {
-                    boolean sucursalExists = franquicia.getListaSucursales().stream()
-                            .anyMatch(sucursal -> sucursal.getIdSucursal().equals(idSucursal));
-                    if (!sucursalExists)
-                        return Mono.error(new IllegalArgumentException("No existe una sucursal con el id: " + idSucursal + " en la franquicia: " + idFranquicia));
-                    return productoRepository.saveProducto(idFranquicia, idSucursal, idProducto, nombreProducto, stock);
-                });
+                .flatMap(sucursal -> sucursalRepository.findByIdSucursal(idSucursal))
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("No existe una sucursal con el id: " + idSucursal)))
+                .flatMap(producto -> productoRepository.saveProducto(idSucursal, idProducto, nombreProducto, stock))
+                ;
     }
 
     @Override
@@ -34,7 +33,7 @@ public class ProductoUseCase implements IProductoUseCase {
                     
                     if (!sucursalExists)
                         return Mono.error(new IllegalArgumentException("No existe una sucursal con el id: " + idSucursal + " en la franquicia: " + idFranquicia));
-                    return productoRepository.deleteProducto(idFranquicia, idSucursal, idProducto);
+                    return productoRepository.deleteProducto(idProducto);
                 });
     }
 
@@ -50,7 +49,7 @@ public class ProductoUseCase implements IProductoUseCase {
                         return Mono.error(new IllegalArgumentException("No existe una sucursal con el id: " + idSucursal + " en la franquicia: " + idFranquicia));
                     if (nuevoStock == null || nuevoStock < 0)
                         return Mono.error(new IllegalArgumentException("El stock no puede ser negativo"));
-                    return productoRepository.updateStockProducto(idFranquicia, idSucursal, idProducto, nuevoStock);
+                    return productoRepository.updateStockProducto(idProducto, nuevoStock);
                 });
     }
 
@@ -66,7 +65,7 @@ public class ProductoUseCase implements IProductoUseCase {
                         return Mono.error(new IllegalArgumentException("No existe una sucursal con el id: " + idSucursal + " en la franquicia: " + idFranquicia));
                     if (nuevoNombreProducto == null || nuevoNombreProducto.trim().isEmpty())
                         return Mono.error(new IllegalArgumentException("El nombre del producto no puede estar vacío"));
-                    return productoRepository.updateNombreProducto(idFranquicia, idSucursal, idProducto, nuevoNombreProducto);
+                    return productoRepository.updateNombreProducto(idProducto, nuevoNombreProducto);
                 });
     }
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/producto/ProductoReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/producto/ProductoReactiveRepositoryAdapter.java
@@ -27,17 +27,16 @@ public class ProductoReactiveRepositoryAdapter extends ReactiveAdapterOperations
     }
 
     @Override
-    public Mono<Producto> saveProducto(Integer idFranquicia, Integer idSucursal, Integer idProducto, String nombreProducto, Integer stock) {
+    public Mono<Producto> saveProducto(Integer IdSucursal, Integer idProducto, String nombreProducto, Integer stock) {
         ProductoEntity entity = new ProductoEntity();
-        entity.setIdProducto(idProducto);
+        entity.setIdSucursal(IdSucursal);
         entity.setNombreProducto(nombreProducto);
         entity.setStock(stock);
         return repository.save(entity)
                 .map(saved -> mapper.map(saved, Producto.class));
     }
-
     @Override
-    public Mono<Producto> updateNombreProducto(Integer idFranquicia, Integer idSucursal, Integer idProducto, String nuevoNombreProducto) {
+    public Mono<Producto> updateNombreProducto(Integer idProducto, String nuevoNombreProducto) {
         return repository.findById(idProducto)
                 .flatMap(entity -> {
                     entity.setNombreProducto(nuevoNombreProducto);
@@ -47,7 +46,7 @@ public class ProductoReactiveRepositoryAdapter extends ReactiveAdapterOperations
     }
 
     @Override
-    public Mono<Producto> updateStockProducto(Integer idFranquicia, Integer idSucursal, Integer idProducto, Integer stock) {
+    public Mono<Producto> updateStockProducto( Integer idProducto, Integer stock) {
         return repository.findById(idProducto)
                 .flatMap(entity -> {
                     entity.setStock(stock);
@@ -57,7 +56,7 @@ public class ProductoReactiveRepositoryAdapter extends ReactiveAdapterOperations
     }
 
     @Override
-    public Mono<Void> deleteProducto(Integer idFranquicia, Integer idSucursal, Integer idProducto) {
+    public Mono<Void> deleteProducto(Integer idProducto) {
         return repository.deleteById(idProducto);
     }
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/producto/ProductoHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/producto/ProductoHandler.java
@@ -1,10 +1,32 @@
 package co.com.franquicias.api.producto;
 
+import co.com.franquicias.api.producto.dto.mapper.ProductoMapper;
+import co.com.franquicias.api.producto.dto.request.RegisterProductoRequestDto;
+import co.com.franquicias.api.sucursal.dto.request.RegisterSucursalRequestDto;
+import co.com.franquicias.usecase.producto.ProductoUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
 
 @Component
 @RequiredArgsConstructor
 public class ProductoHandler {
+    private final ProductoUseCase productoUseCase;
+    private final ProductoMapper productoMapper;
+
+    public Mono<ServerResponse> createProducto(ServerRequest request){
+        return request.bodyToMono(RegisterProductoRequestDto.class)
+                .flatMap(createProducto -> productoUseCase.createProducto(
+                        createProducto.idFranquicia(),
+                        createProducto.idSucursal(),
+                        null,
+                        createProducto.nombreProducto(),
+                        createProducto.stock()
+                ))
+                .map(productoMapper::toResponse)
+                .flatMap(responseCreate -> ServerResponse.ok().bodyValue(responseCreate));
+    }
 
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/producto/ProductoRouter.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/producto/ProductoRouter.java
@@ -1,8 +1,74 @@
 package co.com.franquicias.api.producto;
 
+import co.com.franquicias.api.producto.dto.request.RegisterProductoRequestDto;
+import co.com.franquicias.api.producto.dto.response.RegisterProductoResponseDto;
+import co.com.franquicias.api.sucursal.SucursalHandler;
+import co.com.franquicias.api.sucursal.dto.response.SucursalResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springdoc.core.annotations.RouterOperation;
+import org.springdoc.core.annotations.RouterOperations;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+import static org.springframework.web.reactive.function.server.RequestPredicates.POST;
+import static org.springframework.web.reactive.function.server.RouterFunctions.route;
 
 @Configuration
 public class ProductoRouter {
+
+    @Bean
+    @RouterOperations({
+            @RouterOperation(
+                    path = "/franquicia/sucursal/producto/create",
+                    method = RequestMethod.POST,
+                    beanClass = ProductoHandler.class,
+                    beanMethod = "createProducto",
+                    operation = @Operation(
+                            operationId = "createProduto",
+                            summary = "Crear un nuevo producto para una sucursal",
+                            description = "Endpoint para crear un nuevo producto para una sucursal",
+                            tags = {"Productos"},
+                            requestBody = @RequestBody(
+                                    description = "Datos del producto a crear",
+                                    required = true,
+                                    content = @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = RegisterProductoRequestDto.class)
+                                    )
+                            ),
+                            responses = {
+                                    @ApiResponse(
+                                            responseCode = "200",
+                                            description = "Producto agregado correctamente",
+                                            content = @Content(
+                                                    mediaType = "application/json",
+                                                    schema = @Schema(implementation = RegisterProductoResponseDto.class)
+                                            )
+                                    ),
+                                    @ApiResponse(
+                                            responseCode = "400",
+                                            description = "Datos de entrada inválidos"
+                                    ),
+                                    @ApiResponse(
+                                            responseCode = "500",
+                                            description = "Error interno del servidor"
+                                    )
+                            }
+                    )
+            )
+
+    })
+    public RouterFunction<ServerResponse> routerProducto(ProductoHandler productoHandler){
+        return route(POST("/franquicia/sucursal/producto/create"), productoHandler::createProducto)
+
+                ;
+    }
 
 }


### PR DESCRIPTION
This pull request refactors the product creation workflow to improve separation of concerns and simplify data handling. The main changes include updating the `ProductoUseCase` to validate the existence of a `Sucursal` through a dedicated repository, modifying the `ProductoRepository` interface and its adapter to remove unnecessary franchise context, and adding a new reactive web endpoint for product creation. These updates streamline the process of creating, updating, and deleting products, focusing on `Sucursal` and `Producto` identifiers.

**Domain logic and repository interface updates:**

* The `ProductoUseCase` now uses `SucursalRepository` to validate the existence of a `Sucursal` before creating a product, replacing previous logic that checked for the `Sucursal` within a `Franquicia`. All product operations now depend only on `idSucursal` and `idProducto`, removing the need for `idFranquicia` in the repository methods. [[1]](diffhunk://#diff-3360447f694695c9e7eb5ee9b13fab1cc2d9b354ec547e7becfcc24d3c95124fR15-R23) [[2]](diffhunk://#diff-3360447f694695c9e7eb5ee9b13fab1cc2d9b354ec547e7becfcc24d3c95124fL37-R36) [[3]](diffhunk://#diff-3360447f694695c9e7eb5ee9b13fab1cc2d9b354ec547e7becfcc24d3c95124fL53-R52) [[4]](diffhunk://#diff-3360447f694695c9e7eb5ee9b13fab1cc2d9b354ec547e7becfcc24d3c95124fL69-R68)
* The `ProductoRepository` interface and its R2DBC adapter (`ProductoReactiveRepositoryAdapter`) were refactored to remove `idFranquicia` and simplify method signatures, focusing on `idSucursal` and `idProducto` for product operations. [[1]](diffhunk://#diff-edfed5cedd2d2b4eaa4539ab2a9b562c04ff8880fe715ccdd5de683119120d24L7-R11) [[2]](diffhunk://#diff-1fd7335ccea6a646509c824df7839c085131a9013c7fb9ff2cc0b8a5c6de9105L30-R39) [[3]](diffhunk://#diff-1fd7335ccea6a646509c824df7839c085131a9013c7fb9ff2cc0b8a5c6de9105L50-R49) [[4]](diffhunk://#diff-1fd7335ccea6a646509c824df7839c085131a9013c7fb9ff2cc0b8a5c6de9105L60-R59)

**Model enhancements:**

* The `Producto` domain model was updated to include an `idSucursal` field and now uses Lombok's `@NoArgsConstructor` for better compatibility with frameworks and mapping.

**Configuration changes:**

* The Spring configuration (`UseCasesConfig.java`) was updated to inject the new `SucursalRepository` dependency into `ProductoUseCase`.

**API and endpoint additions:**

* A new reactive web endpoint was added for creating products (`/franquicia/sucursal/producto/create`), including OpenAPI documentation and request/response DTO mapping. The handler uses the updated use case logic and returns a mapped response. [[1]](diffhunk://#diff-07d95e590a49f44f7e8eea58935420bf4c4736e5d9cf26c7cef6e662f25e8fafR3-R30) [[2]](diffhunk://#diff-879d46655988663587fcde615dc724794415a0d4290b77e4a6b7f74565a537e2R3-R73)