### PR TITLE
feat: se agrega el idFranquicia al guardar la sucursal

### DIFF
--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/sucursal/SucursalReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/sucursal/SucursalReactiveRepositoryAdapter.java
@@ -31,6 +31,7 @@ public class SucursalReactiveRepositoryAdapter extends ReactiveAdapterOperations
         SucursalEntity entity = new SucursalEntity();
         entity.setIdSucursal(idSucursal);
         entity.setNombreSucursal(nombreSucursal);
+        entity.setIdFranquicia(idFranquicia);
         return repository.save(entity)
                 .map(saved -> mapper.map(saved, Sucursal.class));
     }


### PR DESCRIPTION
This pull request includes a minor fix to the `saveSucursal` method in `SucursalReactiveRepositoryAdapter.java`. The change ensures that the `idFranquicia` field is correctly set when saving a new `Sucursal` entity.