### PR TITLE
Develop

### DIFF
--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/sucursal/SucursalReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/sucursal/SucursalReactiveRepositoryAdapter.java
@@ -31,6 +31,7 @@ public class SucursalReactiveRepositoryAdapter extends ReactiveAdapterOperations
         SucursalEntity entity = new SucursalEntity();
         entity.setIdSucursal(idSucursal);
         entity.setNombreSucursal(nombreSucursal);
+        entity.setIdFranquicia(idFranquicia);
         return repository.save(entity)
                 .map(saved -> mapper.map(saved, Sucursal.class));
     }


### PR DESCRIPTION
This pull request makes a small change to the `SucursalReactiveRepositoryAdapter` by ensuring that the `idFranquicia` field is set when saving a `Sucursal` entity to the database.

* The `idFranquicia` value is now assigned to the `SucursalEntity` before saving, which ensures the franchise relationship is correctly persisted.