### PR TITLE
Feature implement missing endpoints

### DIFF
--- a/domain/usecase/src/main/java/co/com/franquicias/usecase/franquicia/FranquiciaUseCase.java
+++ b/domain/usecase/src/main/java/co/com/franquicias/usecase/franquicia/FranquiciaUseCase.java
@@ -2,13 +2,9 @@ package co.com.franquicias.usecase.franquicia;
 
 import co.com.franquicias.model.franquicia.Franquicia;
 import co.com.franquicias.model.franquicia.gateways.FranquiciaRepository;
-import co.com.franquicias.model.producto.Producto;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
-import java.util.Comparator;
-import java.util.List;
 
 @RequiredArgsConstructor
 public class FranquiciaUseCase implements IFranquiciaUseCase{
@@ -53,19 +49,8 @@ public class FranquiciaUseCase implements IFranquiciaUseCase{
 
     @Override
     public Flux<Franquicia> findProductoWithMaxStockBySucursal(Integer idFranquicia) {
-        return franquiciaRepository.findByIdFranquicia(idFranquicia)
-                .filter(franquicia -> franquicia.getListaSucursales() != null)
-                .map(franquicia -> {
-                    franquicia.getListaSucursales().forEach(sucursal -> {
-                        if (sucursal.getListaProductos() != null && !sucursal.getListaProductos().isEmpty()) {
-                            Producto maxProducto = sucursal.getListaProductos().stream()
-                                    .max(Comparator.comparingInt(Producto::getStock))
-                                    .orElse(null);
-                            sucursal.setListaProductos(maxProducto != null ? List.of(maxProducto) : List.of());
-                        }
-                    });
-                    return franquicia;
-                })
-                .flux();
+        return franquiciaRepository.findProductoWithMaxStockBySucursal(idFranquicia)
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("No existe una franquicia con el id: " + idFranquicia)))
+                ;
     }
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/franquicia/FranquiciaReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/franquicia/FranquiciaReactiveRepositoryAdapter.java
@@ -3,9 +3,14 @@ package co.com.franquicias.r2dbc.franquicia;
 import co.com.franquicias.model.franquicia.Franquicia;
 import co.com.franquicias.model.franquicia.gateways.FranquiciaRepository;
 import co.com.franquicias.model.producto.Producto;
+import co.com.franquicias.model.sucursal.Sucursal;
 import co.com.franquicias.r2dbc.entity.FranquiciaEntity;
+import co.com.franquicias.r2dbc.entity.ProductoEntity;
 import co.com.franquicias.r2dbc.helper.ReactiveAdapterOperations;
+import co.com.franquicias.r2dbc.sucursal.SucursalReactiveRepository;
+import co.com.franquicias.r2dbc.producto.ProductoReactiveRepository;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
@@ -21,13 +26,22 @@ public class FranquiciaReactiveRepositoryAdapter extends ReactiveAdapterOperatio
     Integer,
         FranquiciaReactiveRepository
 > implements FranquiciaRepository {
-    public FranquiciaReactiveRepositoryAdapter(FranquiciaReactiveRepository repository, ObjectMapper mapper) {
+
+    private final SucursalReactiveRepository sucursalRepository;
+    private final ProductoReactiveRepository productoRepository;
+
+    public FranquiciaReactiveRepositoryAdapter(FranquiciaReactiveRepository repository,
+                                             ObjectMapper mapper,
+                                             SucursalReactiveRepository sucursalRepository,
+                                             ProductoReactiveRepository productoRepository) {
         /**
          *  Could be use mapper.mapBuilder if your domain model implement builder pattern
          *  super(repository, mapper, d -> mapper.mapBuilder(d,ObjectModel.ObjectModelBuilder.class).build());
          *  Or using mapper.map with the class of the object model
          */
         super(repository, mapper, d -> mapper.mapBuilder(d,Franquicia.FranquiciaBuilder.class).build());
+        this.sucursalRepository = sucursalRepository;
+        this.productoRepository = productoRepository;
     }
 
     @Override
@@ -67,24 +81,31 @@ public class FranquiciaReactiveRepositoryAdapter extends ReactiveAdapterOperatio
     @Override
     public Flux<Franquicia> findProductoWithMaxStockBySucursal(Integer idFranquicia) {
         return repository.findById(idFranquicia)
-            .map(entity -> {
-                if (entity.getListaSucursales() != null) {
-                    entity.getListaSucursales().forEach(sucursal -> {
-                        if (sucursal.getListaProductos() != null && !sucursal.getListaProductos().isEmpty()) {
-                            Producto maxStockProducto = sucursal.getListaProductos().stream()
-                                    .max(Comparator.comparingInt(Producto::getStock))
-                                .orElse(null);
-                            List<Producto> productosMax = maxStockProducto != null
-                                ? List.of(mapper.map(maxStockProducto, Producto.class))
-                                : List.of();
-                            sucursal.setListaProductos(productosMax);
-                        } else {
-                            sucursal.setListaProductos(List.of());
-                        }
-                    });
-                }
-                return mapper.map(entity, Franquicia.class);
-            })
-            .flux();
+                .flatMapMany(franquiciaEntity ->
+                        sucursalRepository.findByIdFranquicia(idFranquicia)
+                                .flatMap(sucursalEntity ->
+                                        productoRepository.findByIdSucursal(sucursalEntity.getIdSucursal())
+                                                .collectList()
+                                                .map(productos -> {
+                                                    ProductoEntity maxProducto = productos.stream()
+                                                            .max(Comparator.comparingInt(ProductoEntity::getStock))
+                                                            .orElse(null);
+                                                    
+                                                    List<Producto> productoList = new ArrayList<>();
+                                                    if (maxProducto != null) {
+                                                        productoList.add(mapper.map(maxProducto, Producto.class));
+                                                    }
+                                                    Sucursal sucursal = mapper.map(sucursalEntity, Sucursal.class);
+                                                    sucursal.setListaProductos(productoList);
+                                                    return sucursal;
+                                                })
+                                )
+                                .collectList()
+                                .map(sucursales -> {
+                                    Franquicia franquicia = mapper.map(franquiciaEntity, Franquicia.class);
+                                    franquicia.setListaSucursales(sucursales);
+                                    return franquicia;
+                                })
+                );
     }
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/producto/ProductoReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/producto/ProductoReactiveRepository.java
@@ -3,8 +3,10 @@ package co.com.franquicias.r2dbc.producto;
 import co.com.franquicias.r2dbc.entity.ProductoEntity;
 import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
 
 // TODO: This file is just an example, you should delete or modify it
 public interface ProductoReactiveRepository extends ReactiveCrudRepository<ProductoEntity, Integer>, ReactiveQueryByExampleExecutor<ProductoEntity> {
 
+    Flux<ProductoEntity> findByIdSucursal(Integer idSucursal);
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/sucursal/SucursalReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/franquicias/r2dbc/sucursal/SucursalReactiveRepository.java
@@ -3,8 +3,9 @@ package co.com.franquicias.r2dbc.sucursal;
 import co.com.franquicias.r2dbc.entity.SucursalEntity;
 import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
 
 // TODO: This file is just an example, you should delete or modify it
 public interface SucursalReactiveRepository extends ReactiveCrudRepository<SucursalEntity, Integer>, ReactiveQueryByExampleExecutor<SucursalEntity> {
-
+    Flux<SucursalEntity> findByIdFranquicia(Integer idFranquicia);
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/franquicia/FranquiciaHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/franquicia/FranquiciaHandler.java
@@ -1,9 +1,10 @@
 package co.com.franquicias.api.franquicia;
 
 import co.com.franquicias.api.franquicia.dto.mapper.FranquiciaMapper;
+import co.com.franquicias.api.franquicia.dto.request.FranquiciaRequestDto;
 import co.com.franquicias.api.franquicia.dto.request.RegisterFranquiciaDto;
 import co.com.franquicias.api.franquicia.dto.request.UpdateNombreFranquiciaRequestDto;
-import co.com.franquicias.usecase.franquicia.FranquiciaUseCase;
+import co.com.franquicias.usecase.franquicia.IFranquiciaUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.ServerRequest;
@@ -14,7 +15,7 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class FranquiciaHandler {
 
-    private final FranquiciaUseCase franquiciaUseCase;
+    private final IFranquiciaUseCase franquiciaUseCase;
     private final FranquiciaMapper franquiciaMapper;
 
     public Mono<ServerResponse> registerFranquicia(ServerRequest request){
@@ -34,6 +35,16 @@ public class FranquiciaHandler {
                 ))
                 .map(franquiciaMapper::toResponse)
                 .flatMap(responseUpdate -> ServerResponse.ok().bodyValue(responseUpdate));
+    }
+    public Mono<ServerResponse> getProductoMaxStockForSucursal(ServerRequest request){
+        return request.bodyToMono(FranquiciaRequestDto.class)
+                .flatMapMany(franquicia -> 
+                    franquiciaUseCase.findProductoWithMaxStockBySucursal(franquicia.idFranquicia())
+                )
+                .next()
+                .map(franquiciaMapper::toResponseProductoMax)
+                .flatMap(responseGet -> ServerResponse.ok().bodyValue(responseGet))
+                .switchIfEmpty(ServerResponse.notFound().build());
     }
 
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/franquicia/FranquiciaRouter.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/franquicia/FranquiciaRouter.java
@@ -1,8 +1,10 @@
 package co.com.franquicias.api.franquicia;
 
+import co.com.franquicias.api.franquicia.dto.request.FranquiciaRequestDto;
 import co.com.franquicias.api.franquicia.dto.request.RegisterFranquiciaDto;
 import co.com.franquicias.api.franquicia.dto.request.UpdateNombreFranquiciaRequestDto;
 import co.com.franquicias.api.franquicia.dto.response.FranquiciaResponseDto;
+import co.com.franquicias.api.franquicia.dto.response.ProductoMaxStockResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -98,11 +100,50 @@ public class FranquiciaRouter {
                                     )
                             }
                     )
+            ),
+            @RouterOperation(
+                    path = "/franquicia/get-producto-max-stock",
+                    method = RequestMethod.POST,
+                    beanClass = FranquiciaHandler.class,
+                    beanMethod = "getProductoMaxStockForSucursal",
+                    operation = @Operation(
+                            operationId = "getProductoMaxStockForSucursal",
+                            summary = "Obtener el producto con mayor stock por sucursal en una franquicia",
+                            description = "Endpoint para Obtener el producto con mayor stock por sucursal en una franquicia ",
+                            tags = {"Franquicias"},
+                            requestBody = @RequestBody(
+                                    description = "Datos de la franquici",
+                                    required = true,
+                                    content = @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = FranquiciaRequestDto.class)
+                                    )
+                            ),
+                            responses = {
+                                    @ApiResponse(
+                                            responseCode = "200",
+                                            description = "Franquicia actualizada correctamente",
+                                            content = @Content(
+                                                    mediaType = "application/json",
+                                                    schema = @Schema(implementation = ProductoMaxStockResponseDto.class)
+                                            )
+                                    ),
+                                    @ApiResponse(
+                                            responseCode = "400",
+                                            description = "Datos de entrada inválidos"
+                                    ),
+                                    @ApiResponse(
+                                            responseCode = "500",
+                                            description = "Error interno del servidor"
+                                    )
+                            }
+                    )
             )
     })
     public RouterFunction<ServerResponse> routeFranquicia (FranquiciaHandler franquiciaHandler){
         return route(POST("/franquicia/register"), franquiciaHandler::registerFranquicia)
                 .andRoute(PATCH("/franquicia/update"), franquiciaHandler::updateFranquicia)
+                .andRoute(POST("/franquicia/get-producto-max-stock"), franquiciaHandler::getProductoMaxStockForSucursal)
 
                 ;
     }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/franquicia/dto/mapper/FranquiciaMapper.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/franquicia/dto/mapper/FranquiciaMapper.java
@@ -1,10 +1,50 @@
 package co.com.franquicias.api.franquicia.dto.mapper;
 
 import co.com.franquicias.api.franquicia.dto.response.FranquiciaResponseDto;
+import co.com.franquicias.api.franquicia.dto.response.ProductoMaxStockResponseDto;
 import co.com.franquicias.model.franquicia.Franquicia;
+import co.com.franquicias.model.producto.Producto;
+import co.com.franquicias.model.sucursal.Sucursal;
 import org.mapstruct.Mapper;
+
+import java.util.Collections;
 
 @Mapper(componentModel = "spring")
 public interface FranquiciaMapper {
+    
     FranquiciaResponseDto toResponse(Franquicia franquicia);
+    
+    default ProductoMaxStockResponseDto toResponseProductoMax(Franquicia franquicia) {
+        var sucursales = franquicia.getListaSucursales() == null 
+            ? Collections.<ProductoMaxStockResponseDto.SucursalMaxStockDto>emptyList()
+            : franquicia.getListaSucursales().stream()
+                .map(sucursal -> toSucursalDto(sucursal))
+                .toList();
+        
+        return ProductoMaxStockResponseDto.builder()
+            .idFranquicia(franquicia.getIdFranquicia())
+            .nombreFranquicia(franquicia.getNombreFranquicia())
+            .sucursales(sucursales)
+            .build();
+    }
+    
+    default ProductoMaxStockResponseDto.SucursalMaxStockDto toSucursalDto(Sucursal sucursal) {
+        var producto = sucursal.getListaProductos() != null && !sucursal.getListaProductos().isEmpty()
+            ? toProductoDto(sucursal.getListaProductos().get(0))
+            : null;
+        
+        return ProductoMaxStockResponseDto.SucursalMaxStockDto.builder()
+            .idSucursal(sucursal.getIdSucursal())
+            .nombreSucursal(sucursal.getNombreSucursal())
+            .productoMaxStock(producto)
+            .build();
+    }
+    
+    default ProductoMaxStockResponseDto.ProductoMaxStockDto toProductoDto(Producto producto) {
+        return ProductoMaxStockResponseDto.ProductoMaxStockDto.builder()
+            .idProducto(producto.getIdProducto())
+            .nombreProducto(producto.getNombreProducto())
+            .stock(producto.getStock())
+            .build();
+    }
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/franquicia/dto/request/FranquiciaRequestDto.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/franquicia/dto/request/FranquiciaRequestDto.java
@@ -1,0 +1,6 @@
+package co.com.franquicias.api.franquicia.dto.request;
+
+public record FranquiciaRequestDto(
+        Integer idFranquicia
+) {
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/franquicia/dto/response/ProductoMaxStockResponseDto.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/franquicia/dto/response/ProductoMaxStockResponseDto.java
@@ -1,0 +1,26 @@
+package co.com.franquicias.api.franquicia.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ProductoMaxStockResponseDto(
+        Integer idFranquicia,
+        String nombreFranquicia,
+        List<SucursalMaxStockDto> sucursales
+) {
+    @Builder
+    public record SucursalMaxStockDto(
+            Integer idSucursal,
+            String nombreSucursal,
+            ProductoMaxStockDto productoMaxStock
+    ) {}
+    
+    @Builder
+    public record ProductoMaxStockDto(
+            Integer idProducto,
+            String nombreProducto,
+            Integer stock
+    ) {}
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/sucursal/SucursalHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/sucursal/SucursalHandler.java
@@ -2,6 +2,8 @@ package co.com.franquicias.api.sucursal;
 
 import co.com.franquicias.api.sucursal.dto.mapper.SucursalMapper;
 import co.com.franquicias.api.sucursal.dto.request.RegisterSucursalRequestDto;
+import co.com.franquicias.api.sucursal.dto.request.UpdateNombreSucursalRequestDto;
+import co.com.franquicias.usecase.sucursal.ISucursalUseCase;
 import co.com.franquicias.usecase.sucursal.SucursalUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -12,7 +14,7 @@ import reactor.core.publisher.Mono;
 @Component
 @RequiredArgsConstructor
 public class SucursalHandler {
-    private final SucursalUseCase sucursalUseCase;
+    private final ISucursalUseCase sucursalUseCase;
     private final SucursalMapper sucursalMapper;
 
     public Mono<ServerResponse> createSucursal(ServerRequest request){
@@ -24,6 +26,16 @@ public class SucursalHandler {
                 ))
                 .map(sucursalMapper::toResponse)
                 .flatMap(responseCreate -> ServerResponse.ok().bodyValue(responseCreate));
+    }
+    public Mono<ServerResponse> updateNombreSucursal(ServerRequest request){
+        return request.bodyToMono(UpdateNombreSucursalRequestDto.class)
+                .flatMap(updateNombreSucursal -> sucursalUseCase.updateNombreSucursal(
+                        updateNombreSucursal.idFranquicia(),
+                        updateNombreSucursal.idSucursal(),
+                        updateNombreSucursal.nuevoNombreSucursal()
+                ))
+                .map(sucursalMapper::toResponseUpdateNombre)
+                .flatMap(responseUpdate -> ServerResponse.ok().bodyValue(responseUpdate));
     }
 
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/sucursal/SucursalRouter.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/sucursal/SucursalRouter.java
@@ -1,7 +1,9 @@
 package co.com.franquicias.api.sucursal;
 
 import co.com.franquicias.api.sucursal.dto.request.RegisterSucursalRequestDto;
+import co.com.franquicias.api.sucursal.dto.request.UpdateNombreSucursalRequestDto;
 import co.com.franquicias.api.sucursal.dto.response.SucursalResponseDto;
+import co.com.franquicias.api.sucursal.dto.response.UpdateNombreSucursalResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -60,11 +62,50 @@ public class SucursalRouter {
                                     )
                             }
                     )
+            ),
+            @RouterOperation(
+                    path = "/franquicia/sucursal/update-nombre-sucursal",
+                    method = RequestMethod.PATCH,
+                    beanClass = SucursalHandler.class,
+                    beanMethod = "updateNombreSucursal",
+                    operation = @Operation(
+                            operationId = "updateNombreSucursal",
+                            summary = "Actualizar el nombre de una sucursal",
+                            description = "Endpoint para actualizar el nombre de una sucursal por id",
+                            tags = {"Sucursales"},
+                            requestBody = @RequestBody(
+                                    description = "Datos de la sucursal a actualizar",
+                                    required = true,
+                                    content = @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = UpdateNombreSucursalRequestDto.class)
+                                    )
+                            ),
+                            responses = {
+                                    @ApiResponse(
+                                            responseCode = "200",
+                                            description = "Nombre de la sucursal actualizado correctamente",
+                                            content = @Content(
+                                                    mediaType = "application/json",
+                                                    schema = @Schema(implementation = UpdateNombreSucursalResponseDto.class)
+                                            )
+                                    ),
+                                    @ApiResponse(
+                                            responseCode = "400",
+                                            description = "Datos de entrada inválidos"
+                                    ),
+                                    @ApiResponse(
+                                            responseCode = "500",
+                                            description = "Error interno del servidor"
+                                    )
+                            }
+                    )
             )
 
     })
     public RouterFunction<ServerResponse> routerSucursal(SucursalHandler sucursalHandler){
         return route(POST("/franquicia/sucursal/create"), sucursalHandler::createSucursal)
+                .andRoute(PATCH("/franquicia/sucursal/update-nombre-sucursal"), sucursalHandler::updateNombreSucursal)
 
                 ;
     }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/sucursal/dto/mapper/SucursalMapper.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/sucursal/dto/mapper/SucursalMapper.java
@@ -1,10 +1,12 @@
 package co.com.franquicias.api.sucursal.dto.mapper;
 
 import co.com.franquicias.api.sucursal.dto.response.SucursalResponseDto;
+import co.com.franquicias.api.sucursal.dto.response.UpdateNombreSucursalResponseDto;
 import co.com.franquicias.model.sucursal.Sucursal;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
 public interface SucursalMapper {
         SucursalResponseDto toResponse(Sucursal sucursal);
+        UpdateNombreSucursalResponseDto toResponseUpdateNombre(Sucursal sucursal);
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/sucursal/dto/request/UpdateNombreSucursalRequestDto.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/sucursal/dto/request/UpdateNombreSucursalRequestDto.java
@@ -1,0 +1,14 @@
+package co.com.franquicias.api.sucursal.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "DTO para actualizar el nombre de una sucursal")
+public record UpdateNombreSucursalRequestDto(
+        @Schema(description = "ID de la franquicia donde se encuentra la sucursal", example = "1", required = true)
+        Integer idFranquicia,
+        @Schema(description = "ID de la sucursal a actualizar", example = "1", required = true)
+        Integer idSucursal,
+        @Schema(description = "Nuevo nombre para la sucursal", example = "Bogota", required = true)
+        String nuevoNombreSucursal
+) {
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/sucursal/dto/response/UpdateNombreSucursalResponseDto.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/franquicias/api/sucursal/dto/response/UpdateNombreSucursalResponseDto.java
@@ -1,0 +1,12 @@
+package co.com.franquicias.api.sucursal.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "DTO para devolver el id y nombre actualizado de la sucursal")
+public record UpdateNombreSucursalResponseDto(
+        @Schema(description = "ID de la sucursal actualizada", example = "1", required = true)
+        Integer idSucursal,
+        @Schema(description = "Nombre actualizado de la sucursal", example = "Bogota", required = true)
+        String nombreSucursal
+) {
+}


### PR DESCRIPTION
This pull request introduces a new feature to obtain the product with the highest stock per branch (sucursal) within a franchise, along with related improvements to the reactive web API, repository adapters, and DTOs. The changes include a new endpoint, enhancements in repository methods to efficiently fetch the required data, and updates to mappers and DTOs to support the new response format.

**New Feature: Get Product with Max Stock per Sucursal**

* Added the `get-producto-max-stock` POST endpoint to `FranquiciaRouter` and corresponding handler method in `FranquiciaHandler`, allowing clients to retrieve the product with the highest stock for each branch in a franchise. [[1]](diffhunk://#diff-9498465f14e14e2662d96cdeb78711d8ec041b7b9a4db5036085d53f96f44be6R103-R146) [[2]](diffhunk://#diff-b661d31f12c04e6b4d42f1c6a904fedbd15f1e52ecbb7c0384c761c5976e45cbR39-R48)
* Created new DTOs: `FranquiciaRequestDto` for the request and `ProductoMaxStockResponseDto` for the response, including nested DTOs for sucursal and product details. [[1]](diffhunk://#diff-48caa9b70a26b320361c144a73ce392db9ef018f939e6a947ce9800222dd92b3R1-R6) [[2]](diffhunk://#diff-b39edb8db0e601b9547e31724db69f2678c12606c1a6d9c1469b201e1025dfa3R1-R26)
* Enhanced `FranquiciaMapper` with mapping logic to build the new response structure, converting domain models to the new DTO format for the max stock product per sucursal.

**Repository and Data Access Improvements**

* Refactored `FranquiciaReactiveRepositoryAdapter` to use `SucursalReactiveRepository` and `ProductoReactiveRepository` for fetching sucursales and their products, and implemented logic to select the product with the highest stock per sucursal. [[1]](diffhunk://#diff-25dbf53106c0ae5378f3000111c065af65ad08a8cec1ad2012903cfa83600e7aL24-R44) [[2]](diffhunk://#diff-25dbf53106c0ae5378f3000111c065af65ad08a8cec1ad2012903cfa83600e7aL70-R109)
* Added repository methods `findByIdFranquicia` in `SucursalReactiveRepository` and `findByIdSucursal` in `ProductoReactiveRepository` to support efficient data retrieval for the new feature. [[1]](diffhunk://#diff-4b6a5d80e7343b2c41f97e5df212d88226649cc6bd51641dc3d6012ec88c1314R6-R10) [[2]](diffhunk://#diff-042b915afffc38f069be7401285f3cb1cfcad9d23912f51abce7ccd8f9d5fc94R6-R11)

**Domain Layer Refactoring**

* Updated `FranquiciaUseCase` to delegate the max stock product query to the repository, simplifying business logic and error handling for missing franchises.

These changes collectively provide a robust solution for querying and presenting the product with the highest stock per branch in a franchise, improving both backend efficiency and API usability.